### PR TITLE
Fix: syntax error

### DIFF
--- a/Concerns/TestDatabases.php
+++ b/Concerns/TestDatabases.php
@@ -144,7 +144,7 @@ trait TestDatabases
 
         config()->set(
             "database.connections.{$default}.database",
-            $database,
+            $database
         );
     }
 


### PR DESCRIPTION
After running the composer update
This error occurred `syntax error, unexpected ')'`
[Screenshot](https://prnt.sc/xofh0g)