### PR TITLE
Allow using dot syntax for $responseKey.

### DIFF
--- a/TestResponse.php
+++ b/TestResponse.php
@@ -692,13 +692,13 @@ class TestResponse implements ArrayAccess
 
         $json = $this->json();
 
-        if (! array_key_exists($responseKey, $json)) {
-            PHPUnit::assertArrayNotHasKey($responseKey, $json);
+        if (! Arr::has($json, $responseKey)) {
+            PHPUnit::assertFalse(Arr::has($json, $responseKey));
 
             return $this;
         }
 
-        $errors = $json[$responseKey];
+        $errors = Arr::get($json, $responseKey);
 
         if (is_null($keys) && count($errors) > 0) {
             PHPUnit::fail(

--- a/TestResponse.php
+++ b/TestResponse.php
@@ -698,7 +698,7 @@ class TestResponse implements ArrayAccess
             return $this;
         }
 
-        $errors = Arr::get($json, $responseKey);
+        $errors = Arr::get($json, $responseKey, []);
 
         if (is_null($keys) && count($errors) > 0) {
             PHPUnit::fail(


### PR DESCRIPTION
I just noticed that the `assertJsonMissingValidationErrors()` assertion [does not appreciate the dot syntax](https://github.com/illuminate/testing/blob/59fdeca0cf1b5f7e010c7e9600cacffead5a3c35/TestResponse.php#L718) of the `$responseKey` parameter. However, the `assertJsonValidationErrors()` assertion [appreciates that](https://github.com/illuminate/testing/blob/59fdeca0cf1b5f7e010c7e9600cacffead5a3c35/TestResponse.php#L659).

So if we had a Laravel project with a customised way of exposing JSON validation errors as something like this:
```php
// customised
'message' => $exception->getMessage(),
'validation' => [
  'errors' => $exception->errors(),
],

// default
'message' => $exception->getMessage(),
'errors' => $exception->errors(),
```
the following test would pass:
```php
$this->postJson('/api/users')
    ->assertJsonValidationErrors(
        ['email' => 'The email field is required.'], 
        $responseKey = 'validation.errors',
    )

    // This one will pass as the assertion does not appreciate the dot syntax of the $responseKey parameter
    // as it will try to get this: `$jsonResponse['validation.errors']` rather than `$jsonResponse['validation']['errors']`.
    ->assertJsonMissingValidationErrors(
        ['email'],
        $responseKey = 'validation.errors',
    );
```

So, this PR makes it so it appreciates the dot syntax for the `$responseKey` parameter on the `assertJsonMissingValidationErrors()` assertion as it's partially related assertion `assertJsonValidationErrors()` appreciates it.