### PR TITLE
Allow testing of relative signed routes

### DIFF
--- a/TestResponse.php
+++ b/TestResponse.php
@@ -236,9 +236,10 @@ class TestResponse implements ArrayAccess
      *
      * @param  string|null  $name
      * @param  mixed  $parameters
+     * @param  boolean  $absolute
      * @return $this
      */
-    public function assertRedirectToSignedRoute($name = null, $parameters = [])
+    public function assertRedirectToSignedRoute($name = null, $parameters = [], $absolute = true)
     {
         if (! is_null($name)) {
             $uri = route($name, $parameters);
@@ -252,7 +253,7 @@ class TestResponse implements ArrayAccess
         $request = Request::create($this->headers->get('Location'));
 
         PHPUnit::withResponse($this)->assertTrue(
-            $request->hasValidSignature(), 'The response is not a redirect to a signed route.'
+            $request->hasValidSignature($absolute), 'The response is not a redirect to a signed route.'
         );
 
         if (! is_null($name)) {


### PR DESCRIPTION
Currently, if you are using a relative signed route, you cannot test this value because it always expects to include the domain. However, by adding the `absolute` parameter, we can now test relative signed routes.